### PR TITLE
fixed messages 27 cog and sog valeus

### DIFF
--- a/ais-lib-json/src/main/java/dk/dma/ais/json_decoder_helpers/CommonFieldDecoderHelper.java
+++ b/ais-lib-json/src/main/java/dk/dma/ais/json_decoder_helpers/CommonFieldDecoderHelper.java
@@ -33,6 +33,32 @@ public class CommonFieldDecoderHelper {
         return new DecodedAisFieldObject(cog, text);
     }
 
+    public static DecodedAisFieldObject getSogDFOMessage27(int sog) {
+        String text;
+        if (sog == 63) {
+            text = "Speed over ground not available";
+        } else if (sog == 62) {
+            text = "62.1 knots or higher";
+        } else {
+            double dbl = sog;
+            text = dbl + " knots";
+        }
+        return new DecodedAisFieldObject(sog, text);
+    }
+
+    public static DecodedAisFieldObject getCogDFOMessage27(int cog) {
+        String text;
+        if (cog >= 0 && cog < 360) {
+            double cogTrue = cog;
+            text = cogTrue + " degrees";
+        } else if (cog == 511) {
+            text = "Course over ground not available";
+        } else {
+            text = "These values should not be used";
+        }
+        return new DecodedAisFieldObject(cog, text);
+    }
+
     public static DecodedAisFieldObject getTrueHeadingDFO(int trueHeading) {
         String text;
         if (trueHeading >= 0 && trueHeading < 360) {

--- a/ais-lib-json/src/main/java/dk/dma/ais/json_decoder_helpers/message_decoders/AisMessage27Decoder.java
+++ b/ais-lib-json/src/main/java/dk/dma/ais/json_decoder_helpers/message_decoders/AisMessage27Decoder.java
@@ -55,12 +55,12 @@ public class AisMessage27Decoder extends AisMessageDecoder {
 
     public DecodedAisFieldObject getSogDFO() {
         int sog = aisMessage27.getSog();
-        return CommonFieldDecoderHelper.getSogDFO(sog);
+        return CommonFieldDecoderHelper.getSogDFOMessage27(sog);
     }
 
     public DecodedAisFieldObject getCogDFO() {
         int cog = aisMessage27.getCog();
-        return CommonFieldDecoderHelper.getCogDFO(cog);
+        return CommonFieldDecoderHelper.getCogDFOMessage27(cog);
     }
 
     public DecodedAisFieldObject getGnssPosStatusDFO() {

--- a/ais-lib-json/src/test/java/dk/dma/ais/message_decoders/AisMessage27DecoderTest.java
+++ b/ais-lib-json/src/test/java/dk/dma/ais/message_decoders/AisMessage27DecoderTest.java
@@ -82,13 +82,13 @@ public class AisMessage27DecoderTest {
 
         JSONAssert.assertEquals(
                 DecoderTestHelper.getJson(objectWriter,
-                        CommonFieldDecoderHelper.getSogDFO(0)).toString(),
+                        CommonFieldDecoderHelper.getSogDFOMessage27(0)).toString(),
                 jsonObject.get("sogDFO").toString(),
                 true);
 
         JSONAssert.assertEquals(
                 DecoderTestHelper.getJson(objectWriter,
-                        CommonFieldDecoderHelper.getCogDFO(11)).toString(),
+                        CommonFieldDecoderHelper.getCogDFOMessage27(11)).toString(),
                 jsonObject.get("cogDFO").toString(),
                 true);
 


### PR DESCRIPTION
It was noticed that Message 27 returned incorrect values after the decoding process for cogDFO and sogDFO values. To be more specific the previous methods that are implemented inside the CommonFieldDecoderHelper class are only applicable for the rest of the messages.

So, this PR adds two new methods specifically for Message27 to fix that issue.